### PR TITLE
Cross-Compile: add `go_binary` targets for `linux` and `windows` for both `amd64` and `arm64` architectures

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,3 +26,37 @@ go_binary(
     embed = [":garf_lib"],
     visibility = ["//visibility:public"],
 )
+
+[
+    go_binary(
+        name = "garf-%s-%s" % (os, arch),
+        embed = [":garf_lib"],
+        gc_linkopts = [
+            "-s",
+            "-w",
+        ],
+        goarch = arch,
+        goos = os,
+        pure = "on",
+        visibility = ["//visibility:public"],
+    )
+    for os, arch in [
+        ("linux", "amd64"),
+        ("linux", "arm64")
+    ]
+]
+
+[
+    go_binary(
+        name = "garf-%s-%s" % (os, arch),
+        embed = [":garf_lib"],
+        goarch = arch,
+        goos = os,
+        pure = "on",
+        visibility = ["//visibility:public"],
+    )
+    for os, arch in [
+        ("windows", "amd64"),
+        ("windows", "arm64"),
+    ]
+]

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,7 +37,7 @@ go_binary(
         ],
         goarch = arch,
         goos = os,
-        pure = "on",
+        pure = "off",
         visibility = ["//visibility:public"],
     )
     for os, arch in [
@@ -52,7 +52,7 @@ go_binary(
         embed = [":garf_lib"],
         goarch = arch,
         goos = os,
-        pure = "on",
+        pure = "off",
         visibility = ["//visibility:public"],
     )
     for os, arch in [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,23 @@ bazel_dep(name = "gazelle", version = "0.37.0")
 # Version must be kept in sync with the one in go.mod
 bazel_dep(name = "circl", version = "1.3.7")
 
+# circl has cc_library targets which needs a C++ toolchain
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0")
+
+toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+use_repo(toolchains, "zig_sdk")
+
+register_toolchains(
+    # Linux
+    # Use musl as per:
+    # https://honnef.co/articles/statically-compiled-go-programs-always-even-with-cgo-using-musl/
+    "@zig_sdk//toolchain:linux_amd64_musl",
+    "@zig_sdk//toolchain:linux_arm64_musl",
+    # Windows
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+)
+
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.22.6")
 go_sdk.nogo(nogo = "//:garf_nogo")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -35,12 +35,15 @@
     "https://bcr.bazel.build/modules/gazelle/0.37.0/source.json": "b3adc10e2394e7f63ea88fb1d622d4894bfe9ec6961c493ae9a887723ab16831",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.11.0/source.json": "c73d9ef4268c91bd0c1cd88f1f9dfa08e814b1dbe89b5f594a9f08ba0244d206",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/3.1.0/MODULE.bazel": "ea4b3a25a9417a7db57a8a2f9ebdee91d679823c6274b482b817ed128d81c594",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/3.1.0/source.json": "9d1df0459caefdf41052d360469922a73e219f67c8ce4da0628cc604469822b9",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/21.7/source.json": "bbe500720421e582ff2d18b0802464205138c06056f443184de39fbb8187b09b",
@@ -113,6 +116,55 @@
             "apple_support~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@hermetic_cc_toolchain~//toolchain:ext.bzl%toolchains": {
+      "general": {
+        "bzlTransitiveDigest": "L0EDVXQ1bqh5CxjodeVieW+SjWsjwxFXYEKhUNgMY50=",
+        "usagesDigest": "MxU9VK92W2RNP+Pwt0KrtFrdZJ5UKkv2vIPOnk1wvn0=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "zig_sdk": {
+            "bzlFile": "@@hermetic_cc_toolchain~//toolchain:defs.bzl",
+            "ruleClassName": "zig_repository",
+            "attributes": {
+              "version": "0.12.0",
+              "url_formats": [
+                "https://mirror.bazel.build/ziglang.org/download/{version}/zig-{host_platform}-{version}.{_ext}",
+                "https://ziglang.org/download/{version}/zig-{host_platform}-{version}.{_ext}"
+              ],
+              "host_platform_sha256": {
+                "linux-aarch64": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+                "linux-x86_64": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad",
+                "macos-aarch64": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f",
+                "macos-x86_64": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",
+                "windows-aarch64": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b",
+                "windows-x86_64": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
+              },
+              "host_platform_ext": {
+                "linux-aarch64": "tar.xz",
+                "linux-x86_64": "tar.xz",
+                "macos-aarch64": "tar.xz",
+                "macos-x86_64": "tar.xz",
+                "windows-x86_64": "zip"
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "hermetic_cc_toolchain~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "hermetic_cc_toolchain~",
+            "hermetic_cc_toolchain",
+            "hermetic_cc_toolchain~"
           ]
         ]
       }


### PR DESCRIPTION
Attempt to cross-compile.

## `CGO`

`go_binary` disables `CGO` by default even when a C++ toolchain is configured.

- https://github.com/bazelbuild/rules_go/blob/master/go/modes.rst#build-settings
- https://github.com/bazelbuild/rules_go/blob/master/go/modes.rst#building-pure-go-binaries

When `goos` or `goarch` is set, it also disabled `CGO`.

> This disables cgo by default, since a cross-compiling C/C++ toolchain is rarely available. To force cgo, set `pure` = `off`.

- https://github.com/bazelbuild/rules_go/blob/0d8e8716fbed1879f6e306489ba14e88a78d1a7c/docs/go/core/rules.md#go_binary-goos
- https://github.com/bazelbuild/rules_go/blob/0d8e8716fbed1879f6e306489ba14e88a78d1a7c/docs/go/core/rules.md#go_binary-goarch

## `hermetic_cc_toolchain`: `macos` / `darwin`

`CGO` is currently not supported for MacOS as it requires its SDK.

- https://github.com/uber/hermetic_cc_toolchain#osx-sysroot
- https://github.com/uber/hermetic_cc_toolchain/issues/10
- https://github.com/uber/hermetic_cc_toolchain/issues/131
- https://github.com/ziglang/zig/issues/10299#issuecomment-2045669073

Potentially fixed by: https://github.com/uber/hermetic_cc_toolchain/pull/184
