### PR TITLE
GitHub Actions CI: Do Not Fail Fast on Matrix Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
GitHub Actions by default stops all other running instances if one of them fails.

> `jobs.<job_id>.strategy.fail-fast` applies to the entire matrix. If `jobs.<job_id>.strategy.fail-fast` is set to `true` or its expression evaluates to `true`, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails. This property defaults to `true`.

The intention is not to fail fast but to detect potential issue in each platform, therefore all jobs are expected to continue independently of each other.

Reference
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
- https://www.edwardthomson.com/blog/github_actions_6_fail_fast_matrix_workflows.html
