### PR TITLE
Add `setup-java` to add JDK 21 to the runner host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      
       - name: Build
         run: |
           bazelisk build //...

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "golang.Go",
         "BazelBuild.vscode-bazel",
         "ms-vscode.makefile-tools",
-        "tamasfe.even-better-toml"
+        "tamasfe.even-better-toml",
+        "github.vscode-github-actions"
     ]
 }


### PR DESCRIPTION
As this repo uses `bazel_nojdk` and previously `bazelisk` was not updated to understand the `BAZEL_NOJDK` flag, once GitHub Actions runner updated it the CI started to fail as there's no JDK 21+ setup on the host.