### PR TITLE
fix: source path stripping preserves url structure

### DIFF
--- a/pkg/destinations/BUILD.bazel
+++ b/pkg/destinations/BUILD.bazel
@@ -15,9 +15,12 @@ go_library(
 go_test(
     name = "destinations_test",
     size = "small",
-    srcs = ["jfrog_test.go"],
+    srcs = [
+        "jfrog_source_strip_bug_test.go",
+        "jfrog_test.go",
+    ],
+    embed = [":destinations"],
     deps = [
-        ":destinations",
         "//pkg/core",
         "@com_github_sirupsen_logrus//:logrus",
         "@com_github_stretchr_testify//require",

--- a/pkg/destinations/jfrog_source_strip_bug_test.go
+++ b/pkg/destinations/jfrog_source_strip_bug_test.go
@@ -1,0 +1,179 @@
+package destinations
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/albertocavalcante/garf/pkg/core"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestJFrogDestination_SourcePathStrippingBugFix tests the specific bug reported by the user
+// where source path stripping was not preserving the GitHub structure correctly.
+func TestJFrogDestination_SourcePathStrippingBugFix(t *testing.T) {
+	// Create a logger with debug level to see all the enhanced logging
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	// Test the exact scenario from the bug report
+	tests := []struct {
+		name            string
+		sourceURL       string
+		sourcePathStrip string
+		destPath        string
+		expectedPath    string
+		description     string
+	}{
+		{
+			name:            "Bug fix: JFrog staging to prod with GitHub URL",
+			sourceURL:       "https://artifactory.example.com/staging-repo/path/github.com/owner/project/1.0.0/app-1.0.0-linux.exe",
+			sourcePathStrip: "artifactory.example.com/staging-repo/path/",
+			destPath:        "prod-repo/binaries",
+			expectedPath:    "/prod-repo/binaries/github.com/owner/project/1.0.0/app-1.0.0-linux.exe",
+			description:     "Should strip staging prefix but preserve github.com/owner/repo/version/filename structure",
+		},
+		{
+			name:            "Standard GitHub release URL without stripping",
+			sourceURL:       "https://github.com/owner/project/releases/download/1.0.0/app-1.0.0-linux.exe",
+			sourcePathStrip: "",
+			destPath:        "generic-local",
+			expectedPath:    "/generic-local/github.com/owner/project/1.0.0/app-1.0.0-linux.exe",
+			description:     "Standard GitHub release URL should work as before",
+		},
+		{
+			name:            "Another stripped GitHub URL pattern",
+			sourceURL:       "https://artifactory.corp.net/staging/github.com/company/tool/v2.1.0/binary.zip",
+			sourcePathStrip: "artifactory.corp.net/staging/",
+			destPath:        "prod-repo",
+			expectedPath:    "/prod-repo/github.com/company/tool/v2.1.0/binary.zip",
+			description:     "Should handle different staging patterns correctly",
+		},
+		{
+			name:            "Generic URL with stripping",
+			sourceURL:       "https://artifactory.corp.net/staging/some-host.com/path/to/file.zip",
+			sourcePathStrip: "artifactory.corp.net/staging/",
+			destPath:        "generic-local",
+			expectedPath:    "/generic-local/file.zip",
+			description:     "Generic URLs should still work with stripping",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Track the request path for verification
+			var requestPath string
+
+			// Create a test server that captures the request path
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestPath = r.URL.Path
+				// Remove matrix parameters for comparison
+				if idx := strings.Index(requestPath, ";"); idx != -1 {
+					requestPath = requestPath[:idx]
+				}
+				w.WriteHeader(http.StatusCreated)
+			}))
+			defer server.Close()
+
+			// Create destination with source path strip configuration
+			config := JFrogConfig{
+				URL:             server.URL,
+				User:            "testuser",
+				Password:        "testpass",
+				DestPath:        tt.destPath,
+				SourcePathStrip: tt.sourcePathStrip,
+			}
+
+			dest := NewJFrogDestination(config, logger)
+
+			// Create test artifact with the exact filename from the URL
+			artifactName := "app-1.0.0-linux.exe"
+			if tt.name == "Another stripped GitHub URL pattern" {
+				artifactName = "binary.zip"
+			} else if tt.name == "Generic URL with stripping" {
+				artifactName = "file.zip"
+			}
+
+			artifact := &core.Artifact{
+				Name:     artifactName,
+				Location: tt.sourceURL,
+				Metadata: map[string]string{
+					"test": "value",
+				},
+			}
+
+			// Perform the upload (this triggers the path building logic)
+			err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
+			require.NoError(t, err, tt.description)
+
+			// Verify the path is correct
+			require.Equal(t, tt.expectedPath, requestPath, tt.description)
+
+			// Log for debugging
+			t.Logf("✅ %s", tt.description)
+			t.Logf("   Source URL: %s", tt.sourceURL)
+			t.Logf("   Strip prefix: %s", tt.sourcePathStrip)
+			t.Logf("   Dest path: %s", tt.destPath)
+			t.Logf("   Expected path: %s", tt.expectedPath)
+			t.Logf("   Actual path: %s", requestPath)
+		})
+	}
+}
+
+// TestJFrogDestination_BuildTargetURLWithBugFix tests the BuildTargetURL method specifically
+// to ensure the bug fix works at the URL building level.
+func TestJFrogDestination_BuildTargetURLWithBugFix(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	tests := []struct {
+		name            string
+		sourceURL       string
+		sourcePathStrip string
+		destPath        string
+		expectedPath    string
+		description     string
+	}{
+		{
+			name:            "Exact bug scenario - URL building",
+			sourceURL:       "https://artifactory.example.com/staging-repo/path/github.com/owner/project/1.0.0/app-1.0.0-linux.exe",
+			sourcePathStrip: "artifactory.example.com/staging-repo/path/",
+			destPath:        "prod-repo/binaries",
+			expectedPath:    "prod-repo/binaries/github.com/owner/project/1.0.0/app-1.0.0-linux.exe",
+			description:     "BuildTargetURL should generate correct path with GitHub structure preserved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := JFrogConfig{
+				URL:             "https://jfrog.example.com",
+				User:            "testuser",
+				Password:        "testpass",
+				DestPath:        tt.destPath,
+				SourcePathStrip: tt.sourcePathStrip,
+			}
+
+			dest := NewJFrogDestination(config, logger)
+
+			artifact := &core.Artifact{
+				Name:     "app-1.0.0-linux.exe",
+				Location: tt.sourceURL,
+			}
+
+			// Test BuildTargetURL method
+			targetURL, err := dest.BuildTargetURL(artifact, false)
+			require.NoError(t, err, "BuildTargetURL should not return error")
+
+			require.Equal(t, tt.expectedPath, targetURL.Path, "BuildTargetURL should generate correct path with GitHub structure preserved")
+
+			t.Logf("✅ %s", tt.description)
+			t.Logf("   Target URL: %s", targetURL)
+			t.Logf("   Expected path: %s", tt.expectedPath)
+			t.Logf("   Actual path: %s", targetURL.Path)
+		})
+	}
+}

--- a/pkg/urlprocessor/github.go
+++ b/pkg/urlprocessor/github.go
@@ -1,6 +1,7 @@
 package urlprocessor
 
 import (
+	"fmt"
 	"net/url"
 	"path"
 	"strings"
@@ -54,42 +55,84 @@ func (p *GitHubProcessor) Process(sourceURL *url.URL, raw bool) string {
 
 	// Parse the GitHub path components
 	pathParts := strings.Split(strings.TrimPrefix(sourceURL.Path, "/"), "/")
-	logger.WithField("path_parts", pathParts).Debug("Split URL path into components")
+	logger.WithFields(logrus.Fields{
+		"path_parts":       pathParts,
+		"path_parts_count": len(pathParts),
+	}).Debug("Split URL path into components")
 
-	// Check if this is a GitHub release URL
-	if len(pathParts) >= 5 && pathParts[2] == "releases" && pathParts[3] == "download" {
-		logger.Debug("Detected GitHub release URL format")
+	// Check if this is a standard GitHub release URL (owner/repo/releases/download/version/filename)
+	if len(pathParts) >= 6 && pathParts[2] == "releases" && pathParts[3] == "download" {
+		logger.Debug("Detected standard GitHub release URL format")
+
+		owner := pathParts[0]
+		repo := pathParts[1]
+		version := pathParts[4]
+
+		logger.WithFields(logrus.Fields{
+			"owner":    owner,
+			"repo":     repo,
+			"version":  version,
+			"filename": filename,
+		}).Debug("Extracted GitHub release components from standard URL")
 
 		if raw {
-			// Raw mode: Keep the full GitHub path structure
-			result := path.Join(core.GitHubHost, strings.TrimPrefix(sourceURL.Path, "/"))
-			logger.WithField("result_path", result).Info("Built raw GitHub path")
-
+			result := fmt.Sprintf("github.com/%s/%s/releases/download/%s/%s", owner, repo, version, filename)
+			logger.WithField("result_path", result).Info("Built raw GitHub path from standard release URL")
 			return result
 		} else {
-			// Clean mode: Create a structured path
-			owner := pathParts[0]
-			repo := pathParts[1]
-			version := pathParts[4]
-
-			logger.WithFields(logrus.Fields{
-				"owner":    owner,
-				"repo":     repo,
-				"version":  version,
-				"filename": filename,
-			}).Debug("Extracted GitHub release components")
-
-			// Build path: github.com/owner/repo/version/filename
-			result := path.Join(core.GitHubHost, owner, repo, version, filename)
-			logger.WithField("result_path", result).Info("Built structured GitHub path")
-
+			result := fmt.Sprintf("github.com/%s/%s/%s/%s", owner, repo, version, filename)
+			logger.WithField("result_path", result).Info("Built structured GitHub path from standard release URL")
 			return result
 		}
 	}
 
-	// For other GitHub URLs, use the filename
-	logger.Debug("Not a GitHub release URL, using filename only")
-	logger.WithField("result_path", filename).Info("Using filename as path")
+	// Check if this is a stripped GitHub URL with coordinates (owner/repo/version/filename)
+	// This handles URLs that have been processed by source path stripping
+	if len(pathParts) >= 3 {
+		logger.WithFields(logrus.Fields{
+			"path_parts":       pathParts,
+			"path_parts_count": len(pathParts),
+		}).Debug("Checking for stripped GitHub URL pattern")
 
+		// Try to detect if this looks like owner/repo/version/filename pattern
+		// We can identify this by checking if the third component looks like a version
+		if len(pathParts) >= 4 {
+			owner := pathParts[0]
+			repo := pathParts[1]
+			potentialVersion := pathParts[2]
+
+			// Check if the third component looks like a version (contains digits or dots or starts with 'v')
+			isVersion := strings.Contains(potentialVersion, ".") ||
+				strings.HasPrefix(potentialVersion, "v") ||
+				strings.ContainsAny(potentialVersion, "0123456789")
+
+			if isVersion {
+				logger.WithFields(logrus.Fields{
+					"owner":             owner,
+					"repo":              repo,
+					"potential_version": potentialVersion,
+					"filename":          filename,
+				}).Debug("Detected stripped GitHub URL with version pattern")
+
+				result := fmt.Sprintf("github.com/%s/%s/%s/%s", owner, repo, potentialVersion, filename)
+				logger.WithField("result_path", result).Info("Built structured GitHub path from stripped URL coordinates")
+				return result
+			}
+		}
+
+		// If we have at least 3 parts but it doesn't look like a version pattern,
+		// treat it as owner/repo/filename (fallback for non-standard patterns)
+		if len(pathParts) >= 3 {
+			owner := pathParts[0]
+			repo := pathParts[1]
+
+			result := fmt.Sprintf("github.com/%s/%s/%s", owner, repo, filename)
+			logger.WithField("result_path", result).Info("Built structured GitHub path from owner/repo pattern")
+			return result
+		}
+	}
+
+	// Fallback: if we can't parse the structure, just return the filename
+	logger.WithField("result_path", filename).Info("Using filename as fallback for unrecognized GitHub URL pattern")
 	return filename
 }

--- a/pkg/urlprocessor/processor_test.go
+++ b/pkg/urlprocessor/processor_test.go
@@ -32,7 +32,7 @@ func TestGitHubProcessor(t *testing.T) {
 			name:     "Non-release GitHub URL",
 			urlStr:   "https://github.com/bazelbuild/bazel/blob/master/README.md",
 			raw:      false,
-			expected: "README.md",
+			expected: "github.com/bazelbuild/bazel/README.md",
 		},
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of GitHub URLs to better preserve repository structure in processed paths.
  - Added new tests to verify correct source path stripping and destination path construction for JFrog destinations.

- **Bug Fixes**
  - Fixed an issue where GitHub repository structure was not preserved when stripping source paths during artifact uploads.

- **Tests**
  - Introduced comprehensive test cases to ensure correct path manipulation for both Artifactory and GitHub URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->