### PR TITLE
fix(mirror): improve logging and catch bugs for preserving url paths when the source strip content is empty

### DIFF
--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -255,6 +255,11 @@ func runMirror(flags *MirrorFlags) error {
 			"artifact_name":    result.Artifact.Name,
 			"destination_path": result.DestinationPath,
 		}).Info("Successfully mirrored artifact")
+
+		// Also log with a user-friendly message showing the destination URL
+		if result.DestinationPath != "" {
+			logger.Infof("✓ Mirrored to: %s", result.DestinationPath)
+		}
 	}
 
 	if lastErr == nil {

--- a/cmd/mirror_test.go
+++ b/cmd/mirror_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -270,8 +271,19 @@ func (m *mockDestination) Exists(ctx context.Context, artifact *core.Artifact, r
 	return false, nil
 }
 
-func (m *mockDestination) Put(ctx context.Context, artifact *core.Artifact, reader io.Reader, raw bool) error {
-	return nil
+func (m *mockDestination) Put(ctx context.Context, artifact *core.Artifact, reader io.Reader, raw bool) (string, error) {
+	m.logger.Info("Mock destination: putting artifact")
+
+	// Simulate a destination path
+	destinationPath := fmt.Sprintf("mock-repo/%s", artifact.Name)
+
+	return destinationPath, nil
+}
+
+func (m *mockDestination) BuildDestinationPath(artifact *core.Artifact, raw bool) (string, error) {
+	// Simulate a destination path
+	destinationPath := fmt.Sprintf("mock-repo/%s", artifact.Name)
+	return destinationPath, nil
 }
 
 // Test functions.

--- a/core/jfrog_client.go
+++ b/core/jfrog_client.go
@@ -140,7 +140,8 @@ func (c *JFrogClient) UploadGenericArtifact(
 	}
 
 	// Upload the artifact
-	_, totalFailed, err := c.UploadFiles(artifactory.UploadServiceOptions{}, params)
+	uploadServiceOptions := artifactory.UploadServiceOptions{}
+	_, totalFailed, err := c.ArtifactoryServicesManager.UploadFiles(uploadServiceOptions, params)
 	if err != nil {
 		return fmt.Errorf("failed to upload artifact: %w", err)
 	}

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -20,13 +20,18 @@ type Source interface {
 
 // Destination represents a location where artifacts can be stored.
 type Destination interface {
-	// Put stores an artifact in the destination
+	// Put stores an artifact in the destination and returns the destination path
 	// If raw is true, keeps the original URL structure
-	Put(ctx context.Context, artifact *Artifact, content io.Reader, raw bool) error
+	// Returns the final destination path/URL where the artifact was stored
+	Put(ctx context.Context, artifact *Artifact, content io.Reader, raw bool) (string, error)
 
 	// Exists checks if an artifact already exists in the destination
 	// If raw is true, keeps the original URL structure
 	Exists(ctx context.Context, artifact *Artifact, raw bool) (bool, error)
+
+	// BuildDestinationPath builds the destination path without uploading
+	// This is useful for dry-run mode to show where the artifact would be uploaded
+	BuildDestinationPath(artifact *Artifact, raw bool) (string, error)
 
 	// Validate checks if the destination configuration is valid
 	Validate() error

--- a/pkg/destinations/jfrog.go
+++ b/pkg/destinations/jfrog.go
@@ -282,7 +282,7 @@ func (d *JFrogDestination) tryReconstructURL(afterPrefix string, logger *logrus.
 }
 
 // Put uploads an artifact to JFrog Artifactory.
-func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, content io.Reader, raw bool) error {
+func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, content io.Reader, raw bool) (string, error) {
 	logger := d.logger.WithFields(logrus.Fields{
 		"name":     artifact.Name,
 		"version":  artifact.Version,
@@ -295,7 +295,7 @@ func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, con
 	if artifact.Location == "" {
 		logger.Error("Artifact location cannot be empty")
 
-		return fmt.Errorf("artifact location cannot be empty")
+		return "", fmt.Errorf("artifact location cannot be empty")
 	}
 
 	// Build the target URL
@@ -303,7 +303,7 @@ func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, con
 	if err != nil {
 		logger.WithError(err).Error("Failed to build target URL")
 
-		return err
+		return "", err
 	}
 
 	logger.WithField("target_url", targetURL.String()).Info("Built target URL for upload")
@@ -313,7 +313,7 @@ func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, con
 	if err != nil {
 		logger.WithError(err).Error("Failed to create HTTP request")
 
-		return err
+		return "", err
 	}
 
 	logger.WithFields(logrus.Fields{
@@ -326,7 +326,7 @@ func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, con
 	if err != nil {
 		logger.WithError(err).Error("Failed to send HTTP request to JFrog")
 
-		return fmt.Errorf("failed to upload artifact: %w", err)
+		return "", fmt.Errorf("failed to upload artifact: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -340,12 +340,12 @@ func (d *JFrogDestination) Put(ctx context.Context, artifact *core.Artifact, con
 	if err := d.handleResponse(resp); err != nil {
 		logger.WithError(err).Error("JFrog upload failed")
 
-		return err
+		return "", err
 	}
 
-	logger.Info("Successfully uploaded artifact to JFrog")
+	logger.WithField("destination_url", targetURL.String()).Info("Successfully uploaded artifact to JFrog")
 
-	return nil
+	return targetURL.String(), nil
 }
 
 // Exists checks if an artifact already exists in JFrog Artifactory.
@@ -479,4 +479,35 @@ func (d *JFrogDestination) Validate() error {
 // GetConfig returns the JFrog configuration (used for testing).
 func (d *JFrogDestination) GetConfig() JFrogConfig {
 	return d.config
+}
+
+// BuildDestinationPath builds the destination path without uploading.
+// This is useful for dry-run mode to show where the artifact would be uploaded.
+func (d *JFrogDestination) BuildDestinationPath(artifact *core.Artifact, raw bool) (string, error) {
+	logger := d.logger.WithFields(logrus.Fields{
+		"name":     artifact.Name,
+		"version":  artifact.Version,
+		"location": artifact.Location,
+		"raw_mode": raw,
+	})
+
+	logger.Debug("Building destination path for artifact")
+
+	if artifact.Location == "" {
+		logger.Error("Artifact location cannot be empty")
+		return "", fmt.Errorf("artifact location cannot be empty")
+	}
+
+	// Build the target URL
+	targetURL, err := d.BuildTargetURL(artifact, raw)
+	if err != nil {
+		logger.WithError(err).Error("Failed to build target URL")
+		return "", err
+	}
+
+	// Return the full destination URL
+	destinationPath := targetURL.String()
+	logger.WithField("destination_path", destinationPath).Debug("Built destination path")
+
+	return destinationPath, nil
 }

--- a/pkg/destinations/jfrog_source_strip_bug_test.go
+++ b/pkg/destinations/jfrog_source_strip_bug_test.go
@@ -57,8 +57,16 @@ func TestJFrogDestination_SourcePathStrippingBugFix(t *testing.T) {
 			sourceURL:       "https://artifactory.corp.net/staging/some-host.com/path/to/file.zip",
 			sourcePathStrip: "artifactory.corp.net/staging/",
 			destPath:        "generic-local",
-			expectedPath:    "/generic-local/file.zip",
-			description:     "Generic URLs should still work with stripping",
+			expectedPath:    "/generic-local/some-host.com/path/to/file.zip",
+			description:     "Generic URLs should preserve structure after stripping",
+		},
+		{
+			name:            "BCR URL without stripping (original bug scenario)",
+			sourceURL:       "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.0/source.json",
+			sourcePathStrip: "",
+			destPath:        "staging",
+			expectedPath:    "/staging/bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.0/source.json",
+			description:     "BCR URLs should preserve full structure when no stripping is applied (this was the original bug)",
 		},
 	}
 
@@ -95,6 +103,8 @@ func TestJFrogDestination_SourcePathStrippingBugFix(t *testing.T) {
 				artifactName = "binary.zip"
 			} else if tt.name == "Generic URL with stripping" {
 				artifactName = "file.zip"
+			} else if tt.name == "BCR URL without stripping (original bug scenario)" {
+				artifactName = "source.json"
 			}
 
 			artifact := &core.Artifact{
@@ -106,7 +116,7 @@ func TestJFrogDestination_SourcePathStrippingBugFix(t *testing.T) {
 			}
 
 			// Perform the upload (this triggers the path building logic)
-			err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
+			destinationPath, err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
 			require.NoError(t, err, tt.description)
 
 			// Verify the path is correct
@@ -119,6 +129,9 @@ func TestJFrogDestination_SourcePathStrippingBugFix(t *testing.T) {
 			t.Logf("   Dest path: %s", tt.destPath)
 			t.Logf("   Expected path: %s", tt.expectedPath)
 			t.Logf("   Actual path: %s", requestPath)
+
+			// Log the destination path for debugging
+			t.Logf("Destination path returned: %s", destinationPath)
 		})
 	}
 }

--- a/pkg/destinations/jfrog_test.go
+++ b/pkg/destinations/jfrog_test.go
@@ -267,7 +267,7 @@ func TestJFrogDestinationURLHandling(t *testing.T) {
 			}
 
 			dest := destinations.NewJFrogDestination(config, env.logger)
-			err := dest.Put(context.Background(), &artifact, strings.NewReader("test content"), tt.raw)
+			_, err := dest.Put(context.Background(), &artifact, strings.NewReader("test content"), tt.raw)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -459,7 +459,7 @@ func TestJFrogDestinationArtifactNameInPath(t *testing.T) {
 	}
 
 	dest := destinations.NewJFrogDestination(env.config, env.logger)
-	err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
+	_, err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
 	require.NoError(t, err)
 
 	// Verify that the path contains the artifact name (.exe) not the URL filename (.zip)
@@ -529,7 +529,7 @@ func getSourcePathStripTestCases() []sourcePathStripTestCase {
 			sourceURL:       "https://artifactory.corp.net/staging/github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-win.exe",
 			sourcePathStrip: "",
 			pathChecks: []string{
-				"/generic-local/test-artifact", // When strip prefix is empty, URL is not recognized as GitHub and falls back to simple artifact name
+				"/generic-local/artifactory.corp.net/staging/github.com/bazelbuild/bazel/releases/download/7.2.1/test-artifact", // When strip prefix is empty, preserve full URL structure
 			},
 		},
 		{
@@ -570,7 +570,7 @@ func TestJFrogDestinationSourcePathStripping(t *testing.T) {
 			}
 
 			dest := destinations.NewJFrogDestination(config, env.logger)
-			err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
+			_, err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), false)
 			require.NoError(t, err)
 
 			// Check that expected paths are present
@@ -606,7 +606,7 @@ func TestJFrogDestinationSourcePathStrippingWithRawMode(t *testing.T) {
 	}
 
 	dest := destinations.NewJFrogDestination(config, env.logger)
-	err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), true) // raw=true
+	_, err := dest.Put(context.Background(), artifact, strings.NewReader("test content"), true) // raw=true
 	require.NoError(t, err)
 
 	// In raw mode with stripping, we should get the raw structure but without the stripped prefix
@@ -684,11 +684,11 @@ func TestJFrogDestination_SourcePathStripping_BugFix(t *testing.T) {
 		description     string
 	}{
 		{
-			name:            "Bug fix: JFrog staging to prod with GitHub URL",
-			sourceURL:       "https://art.corp.net/artifactory/generic/project/staging/github.com/bazel.exe",
+			name:            "Bug fix: JFrog staging to prod with generic URL",
+			sourceURL:       "https://art.corp.net/artifactory/generic/project/staging/some-domain.com/path/bazel.exe",
 			sourcePathStrip: "art.corp.net/artifactory/generic/project/staging/",
-			expectedPath:    "generic-local/bazel.exe;test=value", // Should preserve github.com structure but URL reconstruction makes it generic
-			description:     "Should strip staging prefix but preserve github.com path structure",
+			expectedPath:    "generic-local/some-domain.com/path/bazel.exe;test=value", // Should preserve domain structure after stripping
+			description:     "Should strip staging prefix but preserve domain path structure",
 		},
 		{
 			name:            "Complex path stripping with GitHub releases",
@@ -715,8 +715,15 @@ func TestJFrogDestination_SourcePathStripping_BugFix(t *testing.T) {
 			name:            "Generic URL stripping",
 			sourceURL:       "https://artifactory.corp.net/staging/some-host.com/path/to/file.zip",
 			sourcePathStrip: "artifactory.corp.net/staging/",
-			expectedPath:    "generic-local/file.zip;test=value", // Generic processor just uses filename
-			description:     "Should strip prefix from generic URLs",
+			expectedPath:    "generic-local/some-host.com/path/to/file.zip;test=value", // Generic processor preserves structure
+			description:     "Should strip prefix from generic URLs but preserve remaining structure",
+		},
+		{
+			name:            "BCR URL preserves structure",
+			sourceURL:       "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.0/source.json",
+			sourcePathStrip: "",
+			expectedPath:    "generic-local/bcr.bazel.build/modules/hermetic_cc_toolchain/4.0.0/source.json;test=value", // BCR URLs should preserve full structure
+			description:     "BCR URLs should preserve full path structure as reported in the original bug",
 		},
 	}
 

--- a/pkg/mirror/mirror_impl.go
+++ b/pkg/mirror/mirror_impl.go
@@ -193,6 +193,30 @@ func (m *DefaultMirror) downloadAndUploadArtifact(
 	if opts != nil && opts.DryRun && opts.DryRunMode == "all" {
 		logger.Info("Dry run mode 'all' - skipping download and upload")
 
+		// Build destination paths for dry-run feedback even when skipping everything
+		if len(destinations) > 0 {
+			var destinationPaths []string
+			for _, dest := range destinations {
+				raw := false
+				if opts != nil {
+					raw = opts.Raw
+				}
+
+				destPath, err := dest.BuildDestinationPath(artifact, raw)
+				if err != nil {
+					logger.WithError(err).Warn("Failed to build destination path for dry-run")
+				} else {
+					destinationPaths = append(destinationPaths, destPath)
+				}
+			}
+
+			// Set the first destination path in the result for logging
+			if len(destinationPaths) > 0 {
+				result.DestinationPath = destinationPaths[0]
+				logger.WithField("destination_path", result.DestinationPath).Info("Would upload to destination")
+			}
+		}
+
 		return nil
 	}
 
@@ -225,6 +249,28 @@ func (m *DefaultMirror) downloadAndUploadArtifact(
 	if opts != nil && opts.DryRun && opts.DryRunMode == "upload" {
 		logger.Info("Dry run mode 'upload' - skipping upload only")
 
+		// Build destination paths for dry-run feedback
+		var destinationPaths []string
+		for _, dest := range destinations {
+			raw := false
+			if opts != nil {
+				raw = opts.Raw
+			}
+
+			destPath, err := dest.BuildDestinationPath(finalArtifact, raw)
+			if err != nil {
+				logger.WithError(err).Warn("Failed to build destination path for dry-run")
+			} else {
+				destinationPaths = append(destinationPaths, destPath)
+			}
+		}
+
+		// Set the first destination path in the result for logging
+		if len(destinationPaths) > 0 {
+			result.DestinationPath = destinationPaths[0]
+			logger.WithField("destination_path", result.DestinationPath).Info("Would upload to destination")
+		}
+
 		return nil
 	}
 
@@ -250,6 +296,7 @@ func (m *DefaultMirror) downloadAndUploadArtifact(
 	var wg sync.WaitGroup
 
 	errChan := make(chan error, len(destinations))
+	destinationPathChan := make(chan string, len(destinations))
 
 	for i, dest := range destinations {
 		wg.Add(1)
@@ -266,31 +313,44 @@ func (m *DefaultMirror) downloadAndUploadArtifact(
 				raw = opts.Raw
 			}
 
-			if err := d.Put(ctx, finalArtifact, r, raw); err != nil {
+			destinationPath, err := d.Put(ctx, finalArtifact, r, raw)
+			if err != nil {
 				destLogger.WithError(err).Error("Failed to upload to destination")
 				errChan <- fmt.Errorf("failed to upload to destination: %w", err)
 			} else {
-				destLogger.Info("Successfully uploaded to destination")
+				destLogger.WithField("destination_path", destinationPath).Info("Successfully uploaded to destination")
+				destinationPathChan <- destinationPath
 			}
 		}(dest, readers[i], i)
 	}
 
 	wg.Wait()
 	close(errChan)
+	close(destinationPathChan)
 
 	var lastErr error
 	for err := range errChan {
 		lastErr = err
 	}
 
+	// Get the first successful destination path
+	var destinationPath string
+	for path := range destinationPathChan {
+		if destinationPath == "" {
+			destinationPath = path
+		}
+	}
+
 	if lastErr != nil {
 		logger.WithError(lastErr).Error("One or more uploads failed")
 	} else {
-		logger.Info("All uploads completed successfully")
+		logger.WithField("destination_path", destinationPath).Info("All uploads completed successfully")
 	}
 
 	// Update the result artifact to reflect any changes (like from ZIP extraction)
 	result.Artifact = finalArtifact
+	// Set the destination path in the result
+	result.DestinationPath = destinationPath
 
 	return lastErr
 }

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -2,11 +2,13 @@ package mirror_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 
 	"github.com/albertocavalcante/garf/pkg/core"
 	"github.com/albertocavalcante/garf/pkg/mirror"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,10 +30,23 @@ func (s *mockSource) Validate() error {
 
 type mockDestination struct {
 	core.Destination
+	putCalled bool
+	putError  error
+	logger    *logrus.Entry
 }
 
-func (d *mockDestination) Put(ctx context.Context, artifact *core.Artifact, content io.Reader, raw bool) error {
-	return nil
+func (d *mockDestination) Put(ctx context.Context, artifact *core.Artifact, content io.Reader, raw bool) (string, error) {
+	d.putCalled = true
+	d.logger.WithFields(logrus.Fields{
+		"artifact_name":     artifact.Name,
+		"artifact_location": artifact.Location,
+		"raw_mode":          raw,
+	}).Info("Mock destination received artifact")
+
+	// Simulate a destination path
+	destinationPath := fmt.Sprintf("mock-repo/%s", artifact.Name)
+
+	return destinationPath, d.putError
 }
 
 func (d *mockDestination) Exists(ctx context.Context, artifact *core.Artifact, raw bool) (bool, error) {
@@ -40,6 +55,12 @@ func (d *mockDestination) Exists(ctx context.Context, artifact *core.Artifact, r
 
 func (d *mockDestination) Validate() error {
 	return nil
+}
+
+func (d *mockDestination) BuildDestinationPath(artifact *core.Artifact, raw bool) (string, error) {
+	// Simulate a destination path
+	destinationPath := fmt.Sprintf("mock-repo/%s", artifact.Name)
+	return destinationPath, nil
 }
 
 func TestDefaultMirror(t *testing.T) {

--- a/pkg/urlprocessor/urlprocessor.go
+++ b/pkg/urlprocessor/urlprocessor.go
@@ -43,10 +43,15 @@ func NewWithLogger(logger *logrus.Logger) *PathBuilder {
 				canHandle: githubProc.CanProcess,
 				process:   githubProc.Process,
 			},
-			// Default fallback processor
+			// Default fallback processor for non-GitHub URLs
+			// Always preserves full URL structure (host + path)
 			{
 				canHandle: func(u *url.URL) bool { return true },
-				process:   func(u *url.URL, _ bool) string { return path.Base(u.Path) },
+				process: func(u *url.URL, raw bool) string {
+					// The raw flag doesn't affect non-GitHub URLs - they always preserve structure
+					// This ensures that URLs like bcr.bazel.build/modules/... maintain their path structure
+					return u.Host + u.Path
+				},
 			},
 		},
 	}

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,5 @@
 """Build file for tools configuration."""
+
 load("@bazel_env.bzl", "bazel_env")
 
 bazel_env(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved logging with clear confirmation messages showing artifact mirror destinations.
  - Added ability to preview destination paths before upload, enhancing dry-run feedback.

- **Bug Fixes**
  - Fixed URL path handling to preserve full host and path structure when mirroring artifacts, including non-GitHub URLs.

- **Tests**
  - Expanded tests to cover updated path handling and verify destination path logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->