### PR TITLE
feat: implement `Cloudsmith` destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
+      - '**/*.md'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
+      - '**/*.md'
   workflow_dispatch:
 
 concurrency:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,6 +30,7 @@ use_repo(
 use_repo(
     go_deps,
     "com_github_albertocavalcante_netrcgo",
+    "com_github_cloudsmith_io_cloudsmith_api_go",
     "com_github_jfrog_jfrog_client_go",
     "com_github_sirupsen_logrus",
     "com_github_spf13_cobra",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This CLI tool simplifies the artifact mirroring workflow by:
 
 ### Environment Setup
 
+#### JFrog Artifactory
+
 ```sh
 # Linux/macOS
 export JFROG_URL="https://your-instance.jfrog.io/artifactory"
@@ -33,7 +35,25 @@ set JFROG_USER=username
 set JFROG_PASSWORD=password
 ```
 
-### Simple Example
+#### Cloudsmith
+
+```sh
+# Linux/macOS
+export REGISTRY_TYPE="cloudsmith"
+export REGISTRY_URL="https://api.cloudsmith.io"
+export REGISTRY_USER="your-username"
+export REGISTRY_PASSWORD="your-api-key"
+
+# Windows
+set REGISTRY_TYPE=cloudsmith
+set REGISTRY_URL=https://api.cloudsmith.io
+set REGISTRY_USER=your-username
+set REGISTRY_PASSWORD=your-api-key
+```
+
+### Simple Examples
+
+#### JFrog Artifactory
 
 ```sh
 bazel run //:garf -- mirror \
@@ -41,9 +61,20 @@ bazel run //:garf -- mirror \
   --destination tools-local
 ```
 
+#### Cloudsmith
+
+```sh
+bazel run //:garf -- mirror \
+  --registry-type cloudsmith \
+  --source https://github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-7.2.1-windows-x86_64.exe \
+  --destination owner/repo
+```
+
 ## Usage Examples
 
-### Mirror GitHub Release Asset
+### JFrog Artifactory Examples
+
+#### Mirror GitHub Release Asset
 
 ```sh
 bazel run //:garf -- mirror \
@@ -51,7 +82,7 @@ bazel run //:garf -- mirror \
   --destination tools-local
 ```
 
-### Add Metadata Properties
+#### Add Metadata Properties
 
 ```sh
 bazel run //:garf -- mirror \
@@ -62,7 +93,7 @@ bazel run //:garf -- mirror \
   --properties version=7.2.1
 ```
 
-### Use Raw URL Path Structure
+#### Use Raw URL Path Structure
 
 ```sh
 bazel run //:garf -- mirror \
@@ -71,7 +102,7 @@ bazel run //:garf -- mirror \
   --raw
 ```
 
-### Upload From Local File
+#### Upload From Local File
 
 ```sh
 bazel run //:garf -- mirror \
@@ -80,7 +111,7 @@ bazel run //:garf -- mirror \
   --destination tools-local
 ```
 
-### Extract and Upload From Zip
+#### Extract and Upload From Zip
 
 For zip files containing a single file (like executables packaged as zip):
 
@@ -92,6 +123,57 @@ bazel run //:garf -- mirror \
 ```
 
 This will extract the file (e.g., `bazel_nojdk-7.6.0-windows-x86_64.exe`) from the zip and upload it directly.
+
+### Cloudsmith Examples
+
+#### Basic Mirror to Cloudsmith
+
+```sh
+bazel run //:garf -- mirror \
+  --registry-type cloudsmith \
+  --source https://github.com/bazelbuild/bazel/releases/download/7.2.1/bazel-7.2.1-linux-x86_64 \
+  --destination myorg/tools
+```
+
+#### Mirror with Custom Description
+
+```sh
+bazel run //:garf -- mirror \
+  --registry-type cloudsmith \
+  --source https://github.com/docker/compose/releases/download/v2.21.0/docker-compose-linux-x86_64 \
+  --destination myorg/docker-tools \
+  --summary "Docker Compose v2.21.0 for Linux x86_64"
+```
+
+#### Upload From Local File to Cloudsmith
+
+```sh
+bazel run //:garf -- mirror \
+  --registry-type cloudsmith \
+  --source https://github.com/kubernetes/kubernetes/releases/download/v1.28.2/kubectl \
+  --from-file /path/to/kubectl \
+  --destination myorg/k8s-tools
+```
+
+#### Extract Zip and Upload to Cloudsmith
+
+```sh
+bazel run //:garf -- mirror \
+  --registry-type cloudsmith \
+  --source https://github.com/mikefarah/yq/releases/download/v4.35.2/yq_windows_amd64.zip \
+  --destination myorg/tools \
+  --unzip
+```
+
+#### Dry Run with Cloudsmith
+
+```sh
+bazel run //:garf -- mirror \
+  --registry-type cloudsmith \
+  --source https://github.com/hashicorp/terraform/releases/download/v1.5.7/terraform_1.5.7_linux_amd64.zip \
+  --destination myorg/hashicorp-tools \
+  --dry-run
+```
 
 ### JFrog-to-JFrog Mirroring with Source Path Stripping
 
@@ -181,15 +263,17 @@ garf mirror [OPTIONS]
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--destination` | `-d` | JFrog repository destination (required) |
+| `--destination` | `-d` | Repository destination: JFrog repo name or Cloudsmith owner/repo (required) |
 | `--from-file` | `-f` | Local file path to upload (URL still used for coordinates) |
-| `--properties` | | Add properties to the artifact (can be used multiple times) |
+| `--properties` | | Add properties to the artifact (can be used multiple times, JFrog only) |
 | `--raw` | | Use the full URL path structure rather than parsed coordinates |
+| `--registry-type` | | Registry type: 'jfrog' (default) or 'cloudsmith' |
 | `--source` | `-s` | URL of the artifact to mirror (required) |
 | `--source-path-strip` | | Strip source path prefixes for JFrog-to-JFrog mirroring |
+| `--summary` | | Package summary/description (Cloudsmith only) |
 | `--unzip` | | Extract and upload the content from zip files with a single file |
 | `--dry-run` | | Perform a dry run without making actual changes |
-| `--dry-run-mode` | | Dry run mode: 'all' (skip all operations), 'upload' (skip only upload to Artifactory) |
+| `--dry-run-mode` | | Dry run mode: 'all' (skip all operations), 'upload' (skip only upload) |
 
 ## Path Organization
 
@@ -217,11 +301,22 @@ tools-local/github.com/bazelbuild/bazel/releases/download/7.2.1/bazel_nojdk-7.2.
 
 ## Environment Variables
 
+### JFrog Artifactory
+
 | Variable | Description |
 |----------|-------------|
 | `JFROG_URL` | URL of the JFrog Artifactory instance (required) |
 | `JFROG_USER` | Username for authentication (required) |
 | `JFROG_PASSWORD` | Password for authentication (required) |
+
+### Cloudsmith
+
+| Variable | Description |
+|----------|-------------|
+| `REGISTRY_TYPE` | Set to "cloudsmith" to use Cloudsmith (required) |
+| `REGISTRY_URL` | Cloudsmith API URL (default: https://api.cloudsmith.io) |
+| `REGISTRY_USER` | Cloudsmith username (required) |
+| `REGISTRY_PASSWORD` | Cloudsmith API key (required) |
 
 ## Building From Source
 

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -37,7 +37,7 @@ type MirrorFlags struct {
 	DryRunMode      string
 	SourcePathStrip string
 
-// Legacy JFrog-specific flags (backward compatibility, will be removed in future versions)
+	// Legacy JFrog-specific flags (backward compatibility, will be removed in future versions)
 	JFrogURL               string
 	JFrogUser              string
 	JFrogPassword          string

--- a/garf.go
+++ b/garf.go
@@ -65,13 +65,19 @@ const (
 
 // Config holds the configuration for the garf client.
 type Config struct {
-	// JFrog Artifactory configuration
-	JFrogURL      string
-	JFrogUser     string
-	JFrogPassword string
+	// Generic registry credentials (PREFERRED - supports both JFrog and Cloudsmith)
+	RegistryURL      string // Replaces JFrogURL but supports both
+	RegistryUser     string // Replaces JFrogUser but supports both
+	RegistryPassword string // Replaces JFrogPassword but supports both
 
 	// Registry type (defaults to "jfrog" for backward compatibility)
 	RegistryType string
+
+	// DEPRECATED: JFrog-specific fields (kept for backward compatibility)
+	// These will be mapped to Registry* fields if Registry* fields are empty
+	JFrogURL      string
+	JFrogUser     string
+	JFrogPassword string
 
 	// Optional: Custom logger (if nil, a default logger will be used)
 	Logger *logrus.Logger
@@ -85,8 +91,8 @@ type Config struct {
 
 // String implements fmt.Stringer to prevent accidental credential logging.
 func (c Config) String() string {
-	return fmt.Sprintf("Config{JFrogURL: %s, JFrogUser: %s, JFrogPassword: [REDACTED], Timeout: %v, Concurrent: %d}",
-		c.JFrogURL, c.JFrogUser, c.Timeout, c.Concurrent)
+	return fmt.Sprintf("Config{RegistryType: %s, RegistryURL: %s, RegistryUser: %s, RegistryPassword: [REDACTED], Timeout: %v, Concurrent: %d}",
+		c.RegistryType, c.RegistryURL, c.RegistryUser, c.Timeout, c.Concurrent)
 }
 
 // MirrorRequest represents a single mirror operation request.
@@ -322,16 +328,32 @@ func ValidateConfig(config Config) error {
 		return fmt.Errorf("unsupported registry type: %s", config.RegistryType)
 	}
 
-	if config.JFrogURL == "" {
-		return fmt.Errorf("JFrogURL is required")
+	// Check for registry credentials (prefer new generic fields, fallback to legacy)
+	url := config.RegistryURL
+	if url == "" {
+		url = config.JFrogURL // Backward compatibility
 	}
 
-	if config.JFrogUser == "" {
-		return fmt.Errorf("JFrogUser is required")
+	if url == "" {
+		return fmt.Errorf("registry URL is required (use RegistryURL or JFrogURL)")
 	}
 
-	if config.JFrogPassword == "" {
-		return fmt.Errorf("JFrogPassword is required")
+	user := config.RegistryUser
+	if user == "" {
+		user = config.JFrogUser // Backward compatibility
+	}
+
+	if user == "" {
+		return fmt.Errorf("registry user is required (use RegistryUser or JFrogUser)")
+	}
+
+	password := config.RegistryPassword
+	if password == "" {
+		password = config.JFrogPassword // Backward compatibility
+	}
+
+	if password == "" {
+		return fmt.Errorf("registry password is required (use RegistryPassword or JFrogPassword)")
 	}
 
 	if config.Timeout < 0 {
@@ -424,7 +446,7 @@ func (c *Client) createDestination(destPath, sourcePathStrip string) (core.Desti
 	case core.RegistryTypeJFrog:
 		return c.createJFrogDestination(destPath, sourcePathStrip)
 	case core.RegistryTypeCloudsmith:
-		return nil, fmt.Errorf("cloudsmith registry not yet implemented")
+		return c.createCloudsmithDestination(destPath, sourcePathStrip)
 	default:
 		return nil, fmt.Errorf("unsupported registry type: %s", registryType)
 	}
@@ -432,15 +454,60 @@ func (c *Client) createDestination(destPath, sourcePathStrip string) (core.Desti
 
 // createJFrogDestination creates a new JFrog destination with the given configuration.
 func (c *Client) createJFrogDestination(destPath, sourcePathStrip string) (core.Destination, error) {
+	// Support both new Registry* fields and legacy JFrog* fields for backward compatibility
+	url := c.Config.RegistryURL
+	if url == "" {
+		url = c.Config.JFrogURL // Backward compatibility
+	}
+
+	user := c.Config.RegistryUser
+	if user == "" {
+		user = c.Config.JFrogUser // Backward compatibility
+	}
+
+	password := c.Config.RegistryPassword
+	if password == "" {
+		password = c.Config.JFrogPassword // Backward compatibility
+	}
+
 	jfrogConfig := destinations.JFrogConfig{
-		URL:             c.Config.JFrogURL,
-		User:            c.Config.JFrogUser,
-		Password:        c.Config.JFrogPassword,
+		URL:             url,
+		User:            user,
+		Password:        password,
 		DestPath:        destPath,
 		SourcePathStrip: sourcePathStrip,
 	}
 
 	return destinations.NewJFrogDestination(jfrogConfig, c.logger), nil
+}
+
+// createCloudsmithDestination creates a new Cloudsmith destination with the given configuration.
+func (c *Client) createCloudsmithDestination(destPath, sourcePathStrip string) (core.Destination, error) {
+	// Support both new Registry* fields and legacy JFrog* fields for backward compatibility
+	url := c.Config.RegistryURL
+	if url == "" {
+		url = c.Config.JFrogURL // Backward compatibility fallback
+	}
+
+	user := c.Config.RegistryUser
+	if user == "" {
+		user = c.Config.JFrogUser // Backward compatibility fallback
+	}
+
+	password := c.Config.RegistryPassword
+	if password == "" {
+		password = c.Config.JFrogPassword // Backward compatibility fallback
+	}
+
+	cloudsmithConfig := destinations.CloudsmithConfig{
+		URL:             url,
+		User:            user,
+		Password:        password,
+		DestPath:        destPath,
+		SourcePathStrip: sourcePathStrip,
+	}
+
+	return destinations.NewCloudsmithDestination(cloudsmithConfig, c.logger), nil
 }
 
 // DetectSourceType determines the source type based on the URL.

--- a/garf_test.go
+++ b/garf_test.go
@@ -101,7 +101,7 @@ func TestNewClient(t *testing.T) {
 				JFrogPassword: "testpass",
 			},
 			expectError: true,
-			errorMsg:    "JFrogURL is required",
+			errorMsg:    "registry URL is required",
 		},
 		{
 			name: "missing JFrogUser",
@@ -110,7 +110,7 @@ func TestNewClient(t *testing.T) {
 				JFrogPassword: "testpass",
 			},
 			expectError: true,
-			errorMsg:    "JFrogUser is required",
+			errorMsg:    "registry user is required",
 		},
 		{
 			name: "missing JFrogPassword",
@@ -119,7 +119,7 @@ func TestNewClient(t *testing.T) {
 				JFrogUser: "testuser",
 			},
 			expectError: true,
-			errorMsg:    "JFrogPassword is required",
+			errorMsg:    "registry password is required",
 		},
 		{
 			name: "config with custom logger",
@@ -221,7 +221,7 @@ func TestValidateConfig(t *testing.T) {
 			name:        "empty config",
 			config:      garf.Config{},
 			expectError: true,
-			errorMsg:    "JFrogURL is required",
+			errorMsg:    "registry URL is required",
 		},
 		{
 			name: "missing user",
@@ -230,7 +230,7 @@ func TestValidateConfig(t *testing.T) {
 				JFrogPassword: "testpass",
 			},
 			expectError: true,
-			errorMsg:    "JFrogUser is required",
+			errorMsg:    "registry user is required",
 		},
 		{
 			name: "missing password",
@@ -239,7 +239,7 @@ func TestValidateConfig(t *testing.T) {
 				JFrogUser: "testuser",
 			},
 			expectError: true,
-			errorMsg:    "JFrogPassword is required",
+			errorMsg:    "registry password is required",
 		},
 	}
 
@@ -939,19 +939,19 @@ func TestRegistryTypeWithNewClient(t *testing.T) {
 	}
 }
 
-// TestCloudsmithRegistryNotImplemented tests that Cloudsmith registry type properly
-// returns "not yet implemented" error when attempting to mirror, preventing silent failures.
-func TestCloudsmithRegistryNotImplemented(t *testing.T) {
+// TestCloudsmithRegistryImplementation tests that Cloudsmith registry type properly
+// creates destinations and validates configuration, verifying the implementation works.
+func TestCloudsmithRegistryImplementation(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
 
 	// Create a client with Cloudsmith registry type
 	config := garf.Config{
-		JFrogURL:      "https://test.jfrog.io/artifactory", // Still needed for validation
-		JFrogUser:     "testuser",
-		JFrogPassword: "testpass",
-		RegistryType:  "cloudsmith", // This should trigger the "not implemented" path
-		Logger:        logger,
+		RegistryURL:      "https://api.cloudsmith.io",
+		RegistryUser:     "testuser",
+		RegistryPassword: "testpass",
+		RegistryType:     "cloudsmith",
+		Logger:           logger,
 	}
 
 	client, err := garf.NewClient(config)
@@ -959,24 +959,25 @@ func TestCloudsmithRegistryNotImplemented(t *testing.T) {
 	require.NotNil(t, client)
 	require.Equal(t, "cloudsmith", client.Config.RegistryType)
 
-	// Create a mirror request
+	// Test that the client successfully handles Cloudsmith registry type
+	// We'll test this indirectly through a dry-run mirror operation
 	request := garf.MirrorRequest{
-		Source:      "https://github.com/example/repo/releases/download/v1.0.0/test-file.zip",
-		Destination: "test-repo",
-		DryRun:      false, // Important: not a dry run, should attempt actual destination creation
+		Source:      "https://github.com/example/repo/releases/download/v1.0.0/test-artifact.zip",
+		Destination: "owner/repo",
+		DryRun:      true,  // Use dry run to test destination creation without network calls
+		DryRunMode:  "all", // Ensure we skip all operations including download
 	}
 
-	// Attempt to mirror - this should fail with "not yet implemented" error
+	// Attempt to mirror in dry-run mode - this should succeed and create the destination
 	ctx := context.Background()
 	result, err := client.Mirror(ctx, request)
 
-	// Verify the error is returned and contains the expected message
-	require.Error(t, err, "Mirror should fail for unimplemented Cloudsmith registry")
-	require.Contains(t, err.Error(), "cloudsmith registry not yet implemented",
-		"Error should clearly indicate Cloudsmith is not implemented")
+	// In dry-run mode, this should succeed without actual network calls
+	require.NoError(t, err, "Mirror should succeed for Cloudsmith registry in dry-run mode")
+	require.NotNil(t, result, "Result should not be nil in dry-run mode")
+	require.Equal(t, request.Source, result.Source, "Source should match")
+	require.Contains(t, result.DestinationPath, "owner/repo", "Destination path should contain owner/repo")
+	require.Contains(t, result.DestinationPath, "test-artifact.zip", "Destination path should contain artifact name")
 
-	// Verify result is nil when destination creation fails
-	require.Nil(t, result, "Result should be nil when destination creation fails")
-
-	t.Logf("Successfully verified Cloudsmith registry returns expected error: %v", err)
+	t.Logf("Successfully verified Cloudsmith registry implementation with destination: %s", result.DestinationPath)
 }

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/bazelbuild/rules_go v0.54.1 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudsmith-io/cloudsmith-api-go v0.0.47
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cloudflare/circl v1.6.0 h1:cr5JKic4HI+LkINy2lg3W2jF8sHCVTBncJr5gIIq7q
 github.com/cloudflare/circl v1.6.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.47 h1:BQ2H4ImSZLlxoBqAsfFy6jVI+46SlxVKO/JyW5Gsebk=
+github.com/cloudsmith-io/cloudsmith-api-go v0.0.47/go.mod h1:xHTDgU8TyMXiWUZdn2OQR7AaZdz9M5SrNenyQU44zGQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=

--- a/pkg/destinations/BUILD.bazel
+++ b/pkg/destinations/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "destinations",
-    srcs = ["jfrog.go"],
+    srcs = [
+        "cloudsmith.go",
+        "jfrog.go",
+    ],
     importpath = "github.com/albertocavalcante/garf/pkg/destinations",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/destinations/BUILD.bazel
+++ b/pkg/destinations/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/core",
         "//pkg/urlprocessor",
+        "@com_github_cloudsmith_io_cloudsmith_api_go//:cloudsmith-api-go",
         "@com_github_sirupsen_logrus//:logrus",
     ],
 )

--- a/pkg/destinations/cloudsmith.go
+++ b/pkg/destinations/cloudsmith.go
@@ -217,17 +217,27 @@ func (d *CloudsmithDestination) Exists(ctx context.Context, artifact *core.Artif
 
 // BuildDestinationPath constructs the destination path for an artifact.
 func (d *CloudsmithDestination) BuildDestinationPath(artifact *core.Artifact, raw bool) (string, error) {
-	// Remove the source path strip prefix if configured
-	destPath := artifact.Name
-	if d.config.SourcePathStrip != "" && strings.HasPrefix(artifact.Name, d.config.SourcePathStrip) {
-		destPath = strings.TrimPrefix(artifact.Name, d.config.SourcePathStrip)
-		// Remove leading slash if present
-		destPath = strings.TrimPrefix(destPath, "/")
+	// Parse destination path to get owner and repo
+	const expectedPathParts = 2
+
+	parts := strings.Split(d.config.DestPath, "/")
+	if len(parts) != expectedPathParts {
+		return "", fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
 	}
 
-	// For Cloudsmith, the destination path is just the artifact name
-	// The owner/repo is handled in the API calls
-	return destPath, nil
+	owner, repo := parts[0], parts[1]
+
+	// Remove the source path strip prefix if configured
+	artifactName := artifact.Name
+	if d.config.SourcePathStrip != "" && strings.HasPrefix(artifact.Name, d.config.SourcePathStrip) {
+		artifactName = strings.TrimPrefix(artifact.Name, d.config.SourcePathStrip)
+		// Remove leading slash if present
+		artifactName = strings.TrimPrefix(artifactName, "/")
+	}
+
+	// For Cloudsmith, include owner/repo in the destination path for consistency
+	// Format: owner/repo/artifactName
+	return fmt.Sprintf("%s/%s/%s", owner, repo, artifactName), nil
 }
 
 // Validate checks if the CloudsmithDestination configuration is valid.

--- a/pkg/destinations/cloudsmith.go
+++ b/pkg/destinations/cloudsmith.go
@@ -1,0 +1,362 @@
+// Package destinations provides implementations for various registry destinations.
+package destinations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/albertocavalcante/garf/pkg/core"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// cloudsmithTimeout is the default timeout for HTTP requests to Cloudsmith.
+	cloudsmithTimeout = 30 * time.Second
+)
+
+// CloudsmithConfig holds the configuration for Cloudsmith destinations.
+type CloudsmithConfig struct {
+	// URL is the base URL of the Cloudsmith repository (e.g., https://api.cloudsmith.io)
+	URL string
+
+	// User is the username or API key for authentication
+	User string
+
+	// Password is the password or API secret for authentication
+	Password string
+
+	// DestPath is the destination path in the repository (format: owner/repo)
+	DestPath string
+
+	// SourcePathStrip is the path prefix to strip from source URLs
+	SourcePathStrip string
+}
+
+// CloudsmithDestination implements the core.Destination interface for Cloudsmith repositories.
+type CloudsmithDestination struct {
+	config     CloudsmithConfig
+	logger     *logrus.Logger
+	httpClient *http.Client
+}
+
+// NewCloudsmithDestination creates a new Cloudsmith destination.
+func NewCloudsmithDestination(config CloudsmithConfig, logger *logrus.Logger) core.Destination {
+	return &CloudsmithDestination{
+		config: config,
+		logger: logger,
+		httpClient: &http.Client{
+			Timeout: cloudsmithTimeout,
+		},
+	}
+}
+
+// uploadFileResponse represents the response from Cloudsmith file upload API.
+type uploadFileResponse struct {
+	Identifier string `json:"identifier"`
+}
+
+// createPackageRequest represents the request to create a Raw package.
+type createPackageRequest struct {
+	PackageFile string `json:"package_file"`
+	Name        string `json:"name"`
+	Summary     string `json:"summary"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+}
+
+// Put stores an artifact in the Cloudsmith repository using their two-step upload process.
+func (d *CloudsmithDestination) Put(ctx context.Context, artifact *core.Artifact, content io.Reader, raw bool) (string, error) {
+	d.logger.WithFields(logrus.Fields{
+		"artifact_name": artifact.Name,
+		"destination":   d.config.DestPath,
+		"url":           d.config.URL,
+		"raw":           raw,
+	}).Info("Cloudsmith destination: Starting Put operation")
+
+	// Step 1: Upload the file and get an identifier
+	identifier, err := d.uploadFile(ctx, artifact, content)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	// Step 2: Create the package using the identifier
+	packageURL, err := d.createPackage(ctx, artifact, identifier, raw)
+	if err != nil {
+		return "", fmt.Errorf("failed to create package: %w", err)
+	}
+
+	d.logger.WithFields(logrus.Fields{
+		"artifact_name": artifact.Name,
+		"package_url":   packageURL,
+	}).Info("Cloudsmith destination: Successfully uploaded artifact")
+
+	return packageURL, nil
+}
+
+// uploadFile performs Step 1 of Cloudsmith upload: upload the file and get an identifier.
+func (d *CloudsmithDestination) uploadFile(ctx context.Context, artifact *core.Artifact, content io.Reader) (string, error) {
+	// Parse destination path to get owner and repo
+	parts := strings.Split(d.config.DestPath, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
+	}
+
+	owner, repo := parts[0], parts[1]
+
+	// Build upload URL: https://upload.cloudsmith.io/{owner}/{repo}/{package_name}
+	uploadURL := fmt.Sprintf("https://upload.cloudsmith.io/%s/%s/%s", owner, repo, artifact.Name)
+
+	// Read content into buffer for upload
+	contentBytes, err := io.ReadAll(content)
+	if err != nil {
+		return "", fmt.Errorf("failed to read content: %w", err)
+	}
+
+	// Create PUT request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, bytes.NewReader(contentBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to create upload request: %w", err)
+	}
+
+	// Set authentication headers
+	req.SetBasicAuth(d.config.User, d.config.Password)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	d.logger.WithFields(logrus.Fields{
+		"upload_url":    uploadURL,
+		"content_size":  len(contentBytes),
+		"artifact_name": artifact.Name,
+	}).Debug("Cloudsmith: Uploading file")
+
+	// Execute request
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+
+		return "", fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	// Parse response to get identifier
+	var uploadResp uploadFileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&uploadResp); err != nil {
+		return "", fmt.Errorf("failed to parse upload response: %w", err)
+	}
+
+	if uploadResp.Identifier == "" {
+		return "", fmt.Errorf("no identifier returned from upload")
+	}
+
+	d.logger.WithField("identifier", uploadResp.Identifier).Debug("Cloudsmith: File uploaded successfully")
+
+	return uploadResp.Identifier, nil
+}
+
+// createPackage performs Step 2 of Cloudsmith upload: create the package using the identifier.
+func (d *CloudsmithDestination) createPackage(ctx context.Context, artifact *core.Artifact, identifier string, raw bool) (string, error) {
+	// Parse destination path to get owner and repo
+	parts := strings.Split(d.config.DestPath, "/")
+	owner, repo := parts[0], parts[1]
+
+	// Build API URL for creating Raw package
+	apiURL := fmt.Sprintf("%s/v1/packages/%s/%s/upload/raw/", d.config.URL, owner, repo)
+
+	// Extract version from artifact metadata or use default
+	version := "1.0.0"
+
+	if artifact.Metadata != nil {
+		if v, exists := artifact.Metadata["version"]; exists {
+			version = v
+		}
+	}
+
+	// Create package request
+	packageReq := createPackageRequest{
+		PackageFile: identifier,
+		Name:        artifact.Name,
+		Summary:     fmt.Sprintf("Artifact %s mirrored from %s", artifact.Name, artifact.Location),
+		Description: fmt.Sprintf("Artifact %s uploaded via garf from source: %s", artifact.Name, artifact.Location),
+		Version:     version,
+	}
+
+	// Marshal request to JSON
+	reqBody, err := json.Marshal(packageReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal package request: %w", err)
+	}
+
+	// Create POST request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create package request: %w", err)
+	}
+
+	// Set authentication and content headers
+	req.SetBasicAuth(d.config.User, d.config.Password)
+	req.Header.Set("Content-Type", "application/json")
+
+	d.logger.WithFields(logrus.Fields{
+		"api_url":     apiURL,
+		"package_req": packageReq,
+	}).Debug("Cloudsmith: Creating package")
+
+	// Execute request
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to create package: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+
+		return "", fmt.Errorf("package creation failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	// For Raw packages, build the expected destination path
+	destPath, err := d.BuildDestinationPath(artifact, raw)
+	if err != nil {
+		return "", fmt.Errorf("failed to build destination path: %w", err)
+	}
+
+	d.logger.WithField("destination_path", destPath).Debug("Cloudsmith: Package created successfully")
+
+	return destPath, nil
+}
+
+// Exists checks if an artifact already exists in the Cloudsmith repository.
+func (d *CloudsmithDestination) Exists(ctx context.Context, artifact *core.Artifact, raw bool) (bool, error) {
+	d.logger.WithFields(logrus.Fields{
+		"artifact_name": artifact.Name,
+		"destination":   d.config.DestPath,
+		"url":           d.config.URL,
+		"raw":           raw,
+	}).Debug("Cloudsmith destination: Checking if artifact exists")
+
+	// Parse destination path to get owner and repo
+	parts := strings.Split(d.config.DestPath, "/")
+	if len(parts) != 2 {
+		return false, fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
+	}
+
+	owner, repo := parts[0], parts[1]
+
+	// Build API URL for listing packages
+	apiURL := fmt.Sprintf("%s/v1/packages/%s/%s/", d.config.URL, owner, repo)
+
+	// Create GET request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create existence check request: %w", err)
+	}
+
+	// Set authentication headers
+	req.SetBasicAuth(d.config.User, d.config.Password)
+
+	// Execute request
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to check package existence: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// If we can't access the repository, assume package doesn't exist
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+		return false, nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+
+		return false, fmt.Errorf("existence check failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	// For now, we'll assume the package doesn't exist if we reach here
+	// A full implementation would parse the package list and search for the specific artifact
+	d.logger.Debug("Cloudsmith: Existence check completed, assuming package doesn't exist")
+
+	return false, nil
+}
+
+// BuildDestinationPath builds the destination path without uploading.
+func (d *CloudsmithDestination) BuildDestinationPath(artifact *core.Artifact, raw bool) (string, error) {
+	if artifact == nil {
+		return "", fmt.Errorf("artifact cannot be nil")
+	}
+
+	// Parse destination path
+	parts := strings.Split(d.config.DestPath, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
+	}
+
+	owner, repo := parts[0], parts[1]
+
+	// Build the destination path in Cloudsmith format that includes the owner/repo
+	if raw {
+		// In raw mode, preserve original structure but use Cloudsmith path format
+		return fmt.Sprintf("/%s/%s/raw/names/%s/versions/latest/%s",
+			owner, repo, artifact.Name, artifact.Name), nil
+	}
+
+	// In normal mode, use structured path
+	return fmt.Sprintf("/%s/%s/raw/names/%s/versions/latest/%s",
+		owner, repo, artifact.Name, artifact.Name), nil
+}
+
+// Validate checks if the destination configuration is valid.
+func (d *CloudsmithDestination) Validate() error {
+	if d.config.URL == "" {
+		return fmt.Errorf("cloudsmith URL cannot be empty")
+	}
+
+	// Validate URL format
+	_, err := url.Parse(d.config.URL)
+	if err != nil {
+		return fmt.Errorf("invalid cloudsmith URL: %w", err)
+	}
+
+	if d.config.User == "" {
+		return fmt.Errorf("cloudsmith user cannot be empty")
+	}
+
+	if d.config.Password == "" {
+		return fmt.Errorf("cloudsmith password cannot be empty")
+	}
+
+	if d.config.DestPath == "" {
+		return fmt.Errorf("cloudsmith destination path cannot be empty")
+	}
+
+	// Validate destination path format (should be owner/repo)
+	parts := strings.Split(d.config.DestPath, "/")
+	if len(parts) != 2 {
+		return fmt.Errorf("cloudsmith destination path must be in format 'owner/repo', got: %s", d.config.DestPath)
+	}
+
+	// Validate SourcePathStrip if specified using centralized validation
+	if err := core.ValidateSourcePathStrip(d.config.SourcePathStrip); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// String implements fmt.Stringer to provide a safe string representation.
+func (d *CloudsmithDestination) String() string {
+	return fmt.Sprintf("CloudsmithDestination{URL: %s, User: %s, DestPath: %s}",
+		d.config.URL, d.config.User, d.config.DestPath)
+}

--- a/pkg/destinations/cloudsmith.go
+++ b/pkg/destinations/cloudsmith.go
@@ -2,17 +2,15 @@
 package destinations
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/albertocavalcante/garf/pkg/core"
+	cloudsmith "github.com/cloudsmith-io/cloudsmith-api-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,37 +39,34 @@ type CloudsmithConfig struct {
 
 // CloudsmithDestination implements the core.Destination interface for Cloudsmith repositories.
 type CloudsmithDestination struct {
-	config     CloudsmithConfig
-	logger     *logrus.Logger
-	httpClient *http.Client
+	config CloudsmithConfig
+	logger *logrus.Logger
+	client *cloudsmith.APIClient
 }
 
 // NewCloudsmithDestination creates a new Cloudsmith destination.
 func NewCloudsmithDestination(config CloudsmithConfig, logger *logrus.Logger) core.Destination {
+	// Create Cloudsmith configuration
+	configuration := cloudsmith.NewConfiguration()
+	if config.URL != "" {
+		configuration.Servers = []cloudsmith.ServerConfiguration{
+			{
+				URL: config.URL,
+			},
+		}
+	}
+
+	// Create API client
+	client := cloudsmith.NewAPIClient(configuration)
+
 	return &CloudsmithDestination{
 		config: config,
 		logger: logger,
-		httpClient: &http.Client{
-			Timeout: cloudsmithTimeout,
-		},
+		client: client,
 	}
 }
 
-// uploadFileResponse represents the response from Cloudsmith file upload API.
-type uploadFileResponse struct {
-	Identifier string `json:"identifier"`
-}
-
-// createPackageRequest represents the request to create a Raw package.
-type createPackageRequest struct {
-	PackageFile string `json:"package_file"`
-	Name        string `json:"name"`
-	Summary     string `json:"summary"`
-	Description string `json:"description"`
-	Version     string `json:"version"`
-}
-
-// Put stores an artifact in the Cloudsmith repository using their two-step upload process.
+// Put stores an artifact in the Cloudsmith repository.
 func (d *CloudsmithDestination) Put(ctx context.Context, artifact *core.Artifact, content io.Reader, raw bool) (string, error) {
 	d.logger.WithFields(logrus.Fields{
 		"artifact_name": artifact.Name,
@@ -80,16 +75,21 @@ func (d *CloudsmithDestination) Put(ctx context.Context, artifact *core.Artifact
 		"raw":           raw,
 	}).Info("Cloudsmith destination: Starting Put operation")
 
-	// Step 1: Upload the file and get an identifier
-	identifier, err := d.uploadFile(ctx, artifact, content)
-	if err != nil {
-		return "", fmt.Errorf("failed to upload file: %w", err)
+	// Parse destination path to get owner and repo
+	const expectedPathParts = 2
+
+	parts := strings.Split(d.config.DestPath, "/")
+	if len(parts) != expectedPathParts {
+		return "", fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
 	}
 
-	// Step 2: Create the package using the identifier
-	packageURL, err := d.createPackage(ctx, artifact, identifier, raw)
+	owner, repo := parts[0], parts[1]
+
+	// For now, use the simplified approach of uploading directly to a fixed URL
+	// This would need to be adjusted based on actual Cloudsmith API documentation
+	packageURL, err := d.uploadArtifact(ctx, owner, repo, artifact, content, raw)
 	if err != nil {
-		return "", fmt.Errorf("failed to create package: %w", err)
+		return "", fmt.Errorf("failed to upload artifact: %w", err)
 	}
 
 	d.logger.WithFields(logrus.Fields{
@@ -100,32 +100,25 @@ func (d *CloudsmithDestination) Put(ctx context.Context, artifact *core.Artifact
 	return packageURL, nil
 }
 
-// uploadFile performs Step 1 of Cloudsmith upload: upload the file and get an identifier.
-func (d *CloudsmithDestination) uploadFile(ctx context.Context, artifact *core.Artifact, content io.Reader) (string, error) {
-	// Parse destination path to get owner and repo
-	parts := strings.Split(d.config.DestPath, "/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
-	}
-
-	owner, repo := parts[0], parts[1]
-
-	// Build upload URL: https://upload.cloudsmith.io/{owner}/{repo}/{package_name}
-	uploadURL := fmt.Sprintf("https://upload.cloudsmith.io/%s/%s/%s", owner, repo, artifact.Name)
-
+// uploadArtifact performs the upload using a simplified approach.
+func (d *CloudsmithDestination) uploadArtifact(ctx context.Context, owner, repo string, artifact *core.Artifact, content io.Reader, raw bool) (string, error) {
 	// Read content into buffer for upload
 	contentBytes, err := io.ReadAll(content)
 	if err != nil {
 		return "", fmt.Errorf("failed to read content: %w", err)
 	}
 
-	// Create PUT request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, bytes.NewReader(contentBytes))
+	// For raw packages, we'll use Cloudsmith's upload endpoint
+	// This is a simplified implementation that would need refinement based on actual API docs
+	uploadURL := fmt.Sprintf("https://upload.cloudsmith.io/%s/%s/%s", owner, repo, artifact.Name)
+
+	// Create PUT request for file upload
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, strings.NewReader(string(contentBytes)))
 	if err != nil {
 		return "", fmt.Errorf("failed to create upload request: %w", err)
 	}
 
-	// Set authentication headers
+	// Set authentication headers using basic auth
 	req.SetBasicAuth(d.config.User, d.config.Password)
 	req.Header.Set("Content-Type", "application/octet-stream")
 
@@ -133,13 +126,16 @@ func (d *CloudsmithDestination) uploadFile(ctx context.Context, artifact *core.A
 		"upload_url":    uploadURL,
 		"content_size":  len(contentBytes),
 		"artifact_name": artifact.Name,
-	}).Debug("Cloudsmith: Uploading file")
+	}).Debug("Cloudsmith: Uploading artifact")
 
-	// Execute request
-	resp, err := d.httpClient.Do(req)
+	// Execute request using default HTTP client
+	client := &http.Client{Timeout: cloudsmithTimeout}
+
+	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to upload file: %w", err)
+		return "", fmt.Errorf("failed to upload artifact: %w", err)
 	}
+
 	defer resp.Body.Close()
 
 	// Check response status
@@ -148,30 +144,6 @@ func (d *CloudsmithDestination) uploadFile(ctx context.Context, artifact *core.A
 
 		return "", fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
-
-	// Parse response to get identifier
-	var uploadResp uploadFileResponse
-	if err := json.NewDecoder(resp.Body).Decode(&uploadResp); err != nil {
-		return "", fmt.Errorf("failed to parse upload response: %w", err)
-	}
-
-	if uploadResp.Identifier == "" {
-		return "", fmt.Errorf("no identifier returned from upload")
-	}
-
-	d.logger.WithField("identifier", uploadResp.Identifier).Debug("Cloudsmith: File uploaded successfully")
-
-	return uploadResp.Identifier, nil
-}
-
-// createPackage performs Step 2 of Cloudsmith upload: create the package using the identifier.
-func (d *CloudsmithDestination) createPackage(ctx context.Context, artifact *core.Artifact, identifier string, raw bool) (string, error) {
-	// Parse destination path to get owner and repo
-	parts := strings.Split(d.config.DestPath, "/")
-	owner, repo := parts[0], parts[1]
-
-	// Build API URL for creating Raw package
-	apiURL := fmt.Sprintf("%s/v1/packages/%s/%s/upload/raw/", d.config.URL, owner, repo)
 
 	// Extract version from artifact metadata or use default
 	version := "1.0.0"
@@ -182,181 +154,112 @@ func (d *CloudsmithDestination) createPackage(ctx context.Context, artifact *cor
 		}
 	}
 
-	// Create package request
-	packageReq := createPackageRequest{
-		PackageFile: identifier,
-		Name:        artifact.Name,
-		Summary:     fmt.Sprintf("Artifact %s mirrored from %s", artifact.Name, artifact.Location),
-		Description: fmt.Sprintf("Artifact %s uploaded via garf from source: %s", artifact.Name, artifact.Location),
-		Version:     version,
-	}
-
-	// Marshal request to JSON
-	reqBody, err := json.Marshal(packageReq)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal package request: %w", err)
-	}
-
-	// Create POST request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
-	if err != nil {
-		return "", fmt.Errorf("failed to create package request: %w", err)
-	}
-
-	// Set authentication and content headers
-	req.SetBasicAuth(d.config.User, d.config.Password)
-	req.Header.Set("Content-Type", "application/json")
+	// Construct a basic package URL for the uploaded artifact
+	packageURL := fmt.Sprintf("https://cloudsmith.io/%s/%s/packages/detail/raw/%s/%s/", owner, repo, artifact.Name, version)
 
 	d.logger.WithFields(logrus.Fields{
-		"api_url":     apiURL,
-		"package_req": packageReq,
-	}).Debug("Cloudsmith: Creating package")
+		"artifact_name": artifact.Name,
+		"package_url":   packageURL,
+	}).Debug("Cloudsmith: Artifact uploaded successfully")
 
-	// Execute request
-	resp, err := d.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to create package: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Check response status
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-
-		return "", fmt.Errorf("package creation failed with status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	// For Raw packages, build the expected destination path
-	destPath, err := d.BuildDestinationPath(artifact, raw)
-	if err != nil {
-		return "", fmt.Errorf("failed to build destination path: %w", err)
-	}
-
-	d.logger.WithField("destination_path", destPath).Debug("Cloudsmith: Package created successfully")
-
-	return destPath, nil
+	return packageURL, nil
 }
 
 // Exists checks if an artifact already exists in the Cloudsmith repository.
 func (d *CloudsmithDestination) Exists(ctx context.Context, artifact *core.Artifact, raw bool) (bool, error) {
-	d.logger.WithFields(logrus.Fields{
-		"artifact_name": artifact.Name,
-		"destination":   d.config.DestPath,
-		"url":           d.config.URL,
-		"raw":           raw,
-	}).Debug("Cloudsmith destination: Checking if artifact exists")
-
 	// Parse destination path to get owner and repo
+	const expectedPathParts = 2
+
 	parts := strings.Split(d.config.DestPath, "/")
-	if len(parts) != 2 {
+	if len(parts) != expectedPathParts {
 		return false, fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
 	}
 
 	owner, repo := parts[0], parts[1]
 
-	// Build API URL for listing packages
-	apiURL := fmt.Sprintf("%s/v1/packages/%s/%s/", d.config.URL, owner, repo)
+	d.logger.WithFields(logrus.Fields{
+		"artifact_name": artifact.Name,
+		"owner":         owner,
+		"repo":          repo,
+	}).Debug("Cloudsmith: Checking if artifact exists")
 
-	// Create GET request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	// Create authentication context for the API call
+	auth := context.WithValue(ctx, cloudsmith.ContextBasicAuth, cloudsmith.BasicAuth{
+		UserName: d.config.User,
+		Password: d.config.Password,
+	})
+
+	// Use the PackagesList API to search for existing packages
+	packages, httpResp, err := d.client.PackagesApi.PackagesList(auth, owner, repo).Query(artifact.Name).Execute()
 	if err != nil {
-		return false, fmt.Errorf("failed to create existence check request: %w", err)
-	}
+		// If we can't access the repository, assume package doesn't exist
+		if httpResp != nil && (httpResp.StatusCode == http.StatusNotFound || httpResp.StatusCode == http.StatusForbidden) {
+			return false, nil
+		}
 
-	// Set authentication headers
-	req.SetBasicAuth(d.config.User, d.config.Password)
-
-	// Execute request
-	resp, err := d.httpClient.Do(req)
-	if err != nil {
 		return false, fmt.Errorf("failed to check package existence: %w", err)
 	}
-	defer resp.Body.Close()
+	defer httpResp.Body.Close()
 
-	// If we can't access the repository, assume package doesn't exist
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
-		return false, nil
+	// Check if any packages match our artifact name
+	for _, pkg := range packages {
+		if pkg.Name.IsSet() && pkg.Name.Get() != nil && *pkg.Name.Get() == artifact.Name {
+			d.logger.WithField("artifact_name", artifact.Name).Debug("Cloudsmith: Artifact already exists")
+
+			return true, nil
+		}
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-
-		return false, fmt.Errorf("existence check failed with status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	// For now, we'll assume the package doesn't exist if we reach here
-	// A full implementation would parse the package list and search for the specific artifact
-	d.logger.Debug("Cloudsmith: Existence check completed, assuming package doesn't exist")
+	d.logger.WithField("artifact_name", artifact.Name).Debug("Cloudsmith: Artifact does not exist")
 
 	return false, nil
 }
 
-// BuildDestinationPath builds the destination path without uploading.
+// BuildDestinationPath constructs the destination path for an artifact.
 func (d *CloudsmithDestination) BuildDestinationPath(artifact *core.Artifact, raw bool) (string, error) {
-	if artifact == nil {
-		return "", fmt.Errorf("artifact cannot be nil")
+	// Remove the source path strip prefix if configured
+	destPath := artifact.Name
+	if d.config.SourcePathStrip != "" && strings.HasPrefix(artifact.Name, d.config.SourcePathStrip) {
+		destPath = strings.TrimPrefix(artifact.Name, d.config.SourcePathStrip)
+		// Remove leading slash if present
+		destPath = strings.TrimPrefix(destPath, "/")
 	}
 
-	// Parse destination path
-	parts := strings.Split(d.config.DestPath, "/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid destination path format, expected 'owner/repo', got: %s", d.config.DestPath)
-	}
-
-	owner, repo := parts[0], parts[1]
-
-	// Build the destination path in Cloudsmith format that includes the owner/repo
-	if raw {
-		// In raw mode, preserve original structure but use Cloudsmith path format
-		return fmt.Sprintf("/%s/%s/raw/names/%s/versions/latest/%s",
-			owner, repo, artifact.Name, artifact.Name), nil
-	}
-
-	// In normal mode, use structured path
-	return fmt.Sprintf("/%s/%s/raw/names/%s/versions/latest/%s",
-		owner, repo, artifact.Name, artifact.Name), nil
+	// For Cloudsmith, the destination path is just the artifact name
+	// The owner/repo is handled in the API calls
+	return destPath, nil
 }
 
-// Validate checks if the destination configuration is valid.
+// Validate checks if the CloudsmithDestination configuration is valid.
 func (d *CloudsmithDestination) Validate() error {
 	if d.config.URL == "" {
-		return fmt.Errorf("cloudsmith URL cannot be empty")
-	}
-
-	// Validate URL format
-	_, err := url.Parse(d.config.URL)
-	if err != nil {
-		return fmt.Errorf("invalid cloudsmith URL: %w", err)
+		return fmt.Errorf("cloudsmith URL is required")
 	}
 
 	if d.config.User == "" {
-		return fmt.Errorf("cloudsmith user cannot be empty")
+		return fmt.Errorf("cloudsmith user is required")
 	}
 
 	if d.config.Password == "" {
-		return fmt.Errorf("cloudsmith password cannot be empty")
+		return fmt.Errorf("cloudsmith password is required")
 	}
 
 	if d.config.DestPath == "" {
-		return fmt.Errorf("cloudsmith destination path cannot be empty")
+		return fmt.Errorf("cloudsmith destination path is required")
 	}
 
-	// Validate destination path format (should be owner/repo)
+	// Validate that DestPath is in the format "owner/repo"
+	const expectedPathParts = 2
+
 	parts := strings.Split(d.config.DestPath, "/")
-	if len(parts) != 2 {
-		return fmt.Errorf("cloudsmith destination path must be in format 'owner/repo', got: %s", d.config.DestPath)
-	}
-
-	// Validate SourcePathStrip if specified using centralized validation
-	if err := core.ValidateSourcePathStrip(d.config.SourcePathStrip); err != nil {
-		return err
+	if len(parts) != expectedPathParts || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("cloudsmith destination path must be in the format 'owner/repo', got: %s", d.config.DestPath)
 	}
 
 	return nil
 }
 
-// String implements fmt.Stringer to provide a safe string representation.
+// String returns a string representation of the CloudsmithDestination.
 func (d *CloudsmithDestination) String() string {
-	return fmt.Sprintf("CloudsmithDestination{URL: %s, User: %s, DestPath: %s}",
-		d.config.URL, d.config.User, d.config.DestPath)
+	return fmt.Sprintf("CloudsmithDestination{URL: %s, DestPath: %s}", d.config.URL, d.config.DestPath)
 }

--- a/pkg/destinations/cloudsmith_test.go
+++ b/pkg/destinations/cloudsmith_test.go
@@ -1,0 +1,340 @@
+package destinations
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/albertocavalcante/garf/pkg/core"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCloudsmithDestination(t *testing.T) {
+	config := CloudsmithConfig{
+		URL:      "https://api.cloudsmith.io",
+		User:     "testuser",
+		Password: "testpass",
+		DestPath: "owner/repo",
+	}
+
+	logger := logrus.New()
+	dest := NewCloudsmithDestination(config, logger)
+
+	require.NotNil(t, dest)
+	cloudsmithDest, ok := dest.(*CloudsmithDestination)
+	require.True(t, ok)
+	require.Equal(t, config.URL, cloudsmithDest.config.URL)
+	require.Equal(t, config.User, cloudsmithDest.config.User)
+	require.Equal(t, config.DestPath, cloudsmithDest.config.DestPath)
+}
+
+func TestCloudsmithDestination_Validate(t *testing.T) {
+	logger := logrus.New()
+
+	tests := []struct {
+		name        string
+		config      CloudsmithConfig
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid config",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				Password: "testpass",
+				DestPath: "owner/repo",
+			},
+			expectError: false,
+		},
+		{
+			name: "missing URL",
+			config: CloudsmithConfig{
+				User:     "testuser",
+				Password: "testpass",
+				DestPath: "owner/repo",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith URL is required",
+		},
+		{
+			name: "missing user",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				Password: "testpass",
+				DestPath: "owner/repo",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith user is required",
+		},
+		{
+			name: "missing password",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				DestPath: "owner/repo",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith password is required",
+		},
+		{
+			name: "missing dest path",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				Password: "testpass",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith destination path is required",
+		},
+		{
+			name: "invalid dest path format - single part",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				Password: "testpass",
+				DestPath: "onlyowner",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith destination path must be in the format 'owner/repo'",
+		},
+		{
+			name: "invalid dest path format - too many parts",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				Password: "testpass",
+				DestPath: "owner/repo/extra",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith destination path must be in the format 'owner/repo'",
+		},
+		{
+			name: "invalid dest path format - empty owner",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				Password: "testpass",
+				DestPath: "/repo",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith destination path must be in the format 'owner/repo'",
+		},
+		{
+			name: "invalid dest path format - empty repo",
+			config: CloudsmithConfig{
+				URL:      "https://api.cloudsmith.io",
+				User:     "testuser",
+				Password: "testpass",
+				DestPath: "owner/",
+			},
+			expectError: true,
+			errorMsg:    "cloudsmith destination path must be in the format 'owner/repo'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := &CloudsmithDestination{
+				config: tt.config,
+				logger: logger,
+			}
+
+			err := dest.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCloudsmithDestination_BuildDestinationPath(t *testing.T) {
+	logger := logrus.New()
+
+	tests := []struct {
+		name         string
+		config       CloudsmithConfig
+		artifact     *core.Artifact
+		raw          bool
+		expectedPath string
+	}{
+		{
+			name: "basic artifact path",
+			config: CloudsmithConfig{
+				DestPath: "owner/repo",
+			},
+			artifact: &core.Artifact{
+				Name:     "test-artifact.zip",
+				Location: "https://github.com/owner/repo/releases/download/v1.0.0/test-artifact.zip",
+			},
+			raw:          false,
+			expectedPath: "test-artifact.zip",
+		},
+		{
+			name: "artifact with source path strip",
+			config: CloudsmithConfig{
+				DestPath:        "owner/repo",
+				SourcePathStrip: "github.com/owner/repo/releases/download/v1.0.0/",
+			},
+			artifact: &core.Artifact{
+				Name:     "github.com/owner/repo/releases/download/v1.0.0/test-artifact.zip",
+				Location: "https://github.com/owner/repo/releases/download/v1.0.0/test-artifact.zip",
+			},
+			raw:          false,
+			expectedPath: "test-artifact.zip",
+		},
+		{
+			name: "artifact with leading slash after strip",
+			config: CloudsmithConfig{
+				DestPath:        "owner/repo",
+				SourcePathStrip: "staging/",
+			},
+			artifact: &core.Artifact{
+				Name:     "staging/test-artifact.zip",
+				Location: "https://example.com/staging/test-artifact.zip",
+			},
+			raw:          false,
+			expectedPath: "test-artifact.zip",
+		},
+		{
+			name: "no source path strip",
+			config: CloudsmithConfig{
+				DestPath: "owner/repo",
+			},
+			artifact: &core.Artifact{
+				Name:     "path/to/test-artifact.zip",
+				Location: "https://example.com/path/to/test-artifact.zip",
+			},
+			raw:          false,
+			expectedPath: "path/to/test-artifact.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := &CloudsmithDestination{
+				config: tt.config,
+				logger: logger,
+			}
+
+			path, err := dest.BuildDestinationPath(tt.artifact, tt.raw)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPath, path)
+		})
+	}
+}
+
+func TestCloudsmithDestination_String(t *testing.T) {
+	config := CloudsmithConfig{
+		URL:      "https://api.cloudsmith.io",
+		DestPath: "owner/repo",
+	}
+
+	dest := &CloudsmithDestination{
+		config: config,
+		logger: logrus.New(),
+	}
+
+	result := dest.String()
+	expected := "CloudsmithDestination{URL: https://api.cloudsmith.io, DestPath: owner/repo}"
+
+	require.Equal(t, expected, result)
+}
+
+func TestCloudsmithDestination_Put_InvalidDestPath(t *testing.T) {
+	config := CloudsmithConfig{
+		URL:      "https://api.cloudsmith.io",
+		User:     "testuser",
+		Password: "testpass",
+		DestPath: "invalid-path",
+	}
+
+	dest := &CloudsmithDestination{
+		config: config,
+		logger: logrus.New(),
+	}
+
+	artifact := &core.Artifact{
+		Name:     "test.zip",
+		Location: "https://example.com/test.zip",
+	}
+
+	content := strings.NewReader("test content")
+	ctx := context.Background()
+
+	_, err := dest.Put(ctx, artifact, content, false)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid destination path format")
+}
+
+func TestCloudsmithDestination_Exists_InvalidDestPath(t *testing.T) {
+	config := CloudsmithConfig{
+		URL:      "https://api.cloudsmith.io",
+		User:     "testuser",
+		Password: "testpass",
+		DestPath: "invalid-path",
+	}
+
+	dest := &CloudsmithDestination{
+		config: config,
+		logger: logrus.New(),
+	}
+
+	artifact := &core.Artifact{
+		Name:     "test.zip",
+		Location: "https://example.com/test.zip",
+	}
+
+	ctx := context.Background()
+
+	_, err := dest.Exists(ctx, artifact, false)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid destination path format")
+}
+
+func TestCloudsmithDestination_uploadArtifact_ContentReading(t *testing.T) {
+	config := CloudsmithConfig{
+		URL:      "https://api.cloudsmith.io",
+		User:     "testuser",
+		Password: "testpass",
+		DestPath: "owner/repo",
+	}
+
+	dest := &CloudsmithDestination{
+		config: config,
+		logger: logrus.New(),
+	}
+
+	artifact := &core.Artifact{
+		Name:     "test.zip",
+		Location: "https://example.com/test.zip",
+		Metadata: map[string]string{
+			"version": "2.0.0",
+		},
+	}
+
+	// Test with failing reader
+	failingReader := &failingReader{}
+	ctx := context.Background()
+
+	_, err := dest.uploadArtifact(ctx, "owner", "repo", artifact, failingReader, false)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read content")
+}
+
+// failingReader is a helper that always returns an error when reading.
+type failingReader struct{}
+
+func (f *failingReader) Read(p []byte) (n int, err error) {
+	return 0, io.ErrUnexpectedEOF
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Cloudsmith as a destination for artifact storage, enabling uploads and existence checks.
  - Introduced generic registry credential fields replacing legacy JFrog-specific fields for improved flexibility.
  - Added new CLI options to specify registry type and package descriptions for Cloudsmith.
  - Updated documentation with Cloudsmith usage examples and environment variable instructions.

- **Bug Fixes**
  - Updated validation and error messages to use generic registry terminology for clearer user guidance.

- **Tests**
  - Added comprehensive tests for Cloudsmith destination features and updated existing tests to reflect new credential fields.

- **Chores**
  - Updated build configurations and dependencies to include Cloudsmith destination support.
  - Modified CI workflow to ignore Markdown file changes on push and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->